### PR TITLE
Adds attributes to XML for international labels.

### DIFF
--- a/lib/endicia/zplii_label.rb
+++ b/lib/endicia/zplii_label.rb
@@ -11,15 +11,24 @@ module Endicia
 
     def initialize(result)
       self.response_body = filter_response_body(result.body.dup)
-      data               = result["LabelRequestResponse"] || {}
-      encoded_zpl        = data["Base64LabelImage"]
+      data               = result["LabelRequestResponse"] || {Label: {}}
+      encoded_zpl        = data["Base64LabelImage"] || data["Label"]["Image"]
 
       if (data.nil? || encoded_zpl.nil?)
         raise LabelError, (data["ErrorMessage"] || result.body.to_s)
       end
 
+      if encoded_zpl.is_a?(String)
+        decoded_zpl = Base64.decode64(encoded_zpl)
+      elsif encoded_zpl.is_a?(Array)
+        decoded_zpl = data["Label"]["Image"].map{|label| Base64.decode64(label["__content__"])}.join("")
+      elsif encoded_zpl.is_a?(Hash)
+        decoded_zpl = Base64.decode64(data["Label"]["Image"]["__content__"])
+      end
+
+
       @tracking_number   = data["TrackingNumber"]
-      @image             = Base64.decode64 encoded_zpl
+      @image             = decoded_zpl
     end
   end
 end


### PR DESCRIPTION
This commit adds to the `XML` used to purchase postage, so international
labels can be purchased through the gem. To use it one must include a
hash with a `customs` key. Within this hash needs to be certain
attributes. I have included a sample.
```
{
   ContentsType: 'Merchandise', #This is the type of contents.
   CustomsCertify: TRUE, #This is either TRUE or FALSE.
   CustomsSigner: 'Jim Johnson', #This is the name of the certifier.
   ToCountryCode: "GB", #Two character country code.
   CustomsItems: [{
     Description: 'Electric Parts Tubes', #Description of the items being sent.
     Quantity: 6, #Quantity of items.
     Weight: 2.5, #Weight in ounces
     Value: 13.86, #Value of items being sent.
     CountryOfOrigin: 'US' #Country items were made.
   }]
}
```
The `CustomsItems` is expected to be an array even if its length is one.
as to any other questions about the particular attributes one can check
the [Endicia Api Docs](https://www.endicia.com/developer/docs/v8.9.html#endicia-els-api),
and search the attributes, because the naming used corresponds with the
`XML` attributes, that are needed, within the documentation.